### PR TITLE
chore: Make qualification and review scheduling atomic.

### DIFF
--- a/components/features/English/practice/speaking-practice.tsx
+++ b/components/features/English/practice/speaking-practice.tsx
@@ -18,7 +18,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import { createClient } from "@/lib/supabase/client";
+
 import { PronunciationResultState } from "@/types/pronunciation";
 import { VocabularyCard } from "@/types/vocabulary";
 import { qualifyVocabSkill } from "@/utils/Supabase/action";
@@ -39,7 +39,6 @@ export const initialPronunciationResultState: PronunciationResultState = {
 };
 
 export default function SpeakingPractice({ cards = [] }: SpeakingPracticeProps) {
-  const supabase = createClient();
   const [currentCardIndex, setCurrentCardIndex] = useState(0);
   const [showDefinition, setShowDefinition] = useState(false);
   const [isPronunciationQualified, setIsPronunciationQualified] = useState(false);
@@ -251,38 +250,6 @@ export default function SpeakingPractice({ cards = [] }: SpeakingPracticeProps) 
       // 1. Qualify pronunciation + mastery +1
       await qualifyVocabSkill(currentCard.id, "speaking");
 
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      if (userError || !user) {
-        throw new Error("User not authenticated");
-      }
-
-      // 2. Add to speaking review queue
-      const tomorrow = new Date();
-      tomorrow.setDate(tomorrow.getDate() + 1);
-
-      const { error } = await supabase.from("user_vocab_progress").upsert(
-        {
-          user_id: user.id,
-          vocabulary_id: currentCard.id,
-          skill_code: "speaking",
-          next_review_at: tomorrow.toISOString().split("T")[0],
-        },
-        {
-          onConflict: "user_id,vocabulary_id,skill_code",
-        }
-      );
-
-      setIsPronunciationQualified(true);
-
-      if (error) {
-        throw error;
-      }
-
-      // 3. Update current UI
       setIsPronunciationQualified(true);
     } catch (error) {
       console.error("Error qualifying pronunciation:", error);

--- a/components/features/English/practice/vocabulary-practice.tsx
+++ b/components/features/English/practice/vocabulary-practice.tsx
@@ -11,7 +11,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { createClient } from "@/lib/supabase/client";
 import { VocabularyCard } from "@/types/vocabulary";
 import { cn } from "@/utils";
 import { qualifyVocabSkill } from "@/utils/Supabase/action";
@@ -20,13 +19,13 @@ import { ArrowRight, BookText, Check, Volume2, X } from "lucide-react";
 import { useState } from "react";
 
 export function VocabularyPractice({ vocabularies }: { vocabularies: VocabularyCard[] }) {
-  const supabase = createClient();
   const [cards] = useState<VocabularyCard[]>(vocabularies);
 
   const [currentCardIndex, setCurrentCardIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
   const [knownWords, setKnownWords] = useState<string[]>([]);
   const [unknownWords, setUnknownWords] = useState<string[]>([]);
+  const [isQualifying, setIsQualifying] = useState(false);
 
   if (cards.length === 0) {
     return (
@@ -44,59 +43,27 @@ export function VocabularyPractice({ vocabularies }: { vocabularies: VocabularyC
   const currentCard = cards[currentCardIndex];
   const progress = cards.length > 0 ? ((currentCardIndex + 1) / cards.length) * 100 : 0;
 
-  async function handleKnown(card: VocabularyCard) {
-    await qualifyVocabSkill(card.id, "recognition");
-
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      throw new Error("User not authenticated");
-    }
-
-    const { error } = await supabase.from("user_vocab_progress").upsert(
-      {
-        user_id: user.id,
-        vocabulary_id: card.id,
-        skill_code: "recognition",
-        next_review_at: tomorrow.toISOString(),
-      },
-      {
-        onConflict: "user_id,vocabulary_id,skill_code",
-      }
-    );
-
-    if (error) {
-      console.error("Error adding to review queue:", error.message, error.code, error.details);
-
-      throw error;
-    }
-  }
-
   const flipCard = () => {
     setIsFlipped(!isFlipped);
   };
 
   const markAsKnown = async () => {
-    if (!currentCard) return;
+    if (!currentCard || isQualifying) return;
+
+    setIsQualifying(true);
+
     try {
-      await handleKnown(currentCard);
+      await qualifyVocabSkill(currentCard.id, "recognition");
+
+      setKnownWords((prev) => (prev.includes(currentCard.id) ? prev : [...prev, currentCard.id]));
+
+      nextCard();
     } catch (error) {
       console.error("Error marking vocabulary as known:", error);
-      return;
+    } finally {
+      setIsQualifying(false);
     }
-
-    if (!knownWords.includes(currentCard.id)) {
-      setKnownWords([...knownWords, currentCard.id]);
-    }
-
-    nextCard();
   };
-
   const markAsUnknown = () => {
     if (!currentCard) return;
     if (!unknownWords.includes(currentCard.id)) {

--- a/components/features/English/practice/vocabulary-practice.tsx
+++ b/components/features/English/practice/vocabulary-practice.tsx
@@ -210,7 +210,12 @@ export function VocabularyPractice({ vocabularies }: { vocabularies: VocabularyC
               whileTap={{ scale: 0.95 }}
               transition={{ type: "spring", stiffness: 400, damping: 10 }}
             >
-              <Button onClick={markAsUnknown} variant="outline" className="flex items-center">
+              <Button
+                onClick={markAsUnknown}
+                disabled={isQualifying}
+                variant="outline"
+                className="flex items-center"
+              >
                 <X className="mr-2 h-4 w-4" />
                 <span className="hidden sm:inline"> Dont Know</span>
               </Button>
@@ -222,6 +227,7 @@ export function VocabularyPractice({ vocabularies }: { vocabularies: VocabularyC
             >
               <Button
                 onClick={nextCard}
+                disabled={isQualifying}
                 variant="outline"
                 className="flex items-center"
                 aria-label="Next card"
@@ -234,7 +240,12 @@ export function VocabularyPractice({ vocabularies }: { vocabularies: VocabularyC
               whileTap={{ scale: 0.95 }}
               transition={{ type: "spring", stiffness: 400, damping: 10 }}
             >
-              <Button onClick={markAsKnown} variant="outline" className="flex items-center">
+              <Button
+                onClick={markAsKnown}
+                disabled={isQualifying}
+                variant="outline"
+                className="flex items-center"
+              >
                 <Check className="mr-2 h-4 w-4" />
                 <span className="hidden sm:inline">Know</span>
               </Button>

--- a/components/features/English/practice/vocabulary-practice.tsx
+++ b/components/features/English/practice/vocabulary-practice.tsx
@@ -64,6 +64,7 @@ export function VocabularyPractice({ vocabularies }: { vocabularies: VocabularyC
       setIsQualifying(false);
     }
   };
+
   const markAsUnknown = () => {
     if (!currentCard) return;
     if (!unknownWords.includes(currentCard.id)) {

--- a/utils/Supabase/action.ts
+++ b/utils/Supabase/action.ts
@@ -12,7 +12,8 @@ export async function qualifyVocabSkill(vocabularyId: string, skillCode: Qualifi
 
   if (error) {
     console.error("Failed to qualify vocabulary skill:", error);
-    throw new Error("Failed to qualify vocabulary skill");
+
+    throw error;
   }
 
   return data;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled vocabulary practice controls while qualification is processing, preventing duplicate submissions and unintended card changes.
  * Cards now advance only after successful skill qualification.
  * Qualification errors no longer advance the practice session, with improved error details.
  * Streamlined speaking practice qualification for more reliable progress updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->